### PR TITLE
feat: add variant support

### DIFF
--- a/src/Themer.js
+++ b/src/Themer.js
@@ -5,6 +5,7 @@
  */
 
 import uuid from 'uuid';
+import { variantApply } from './utils';
 import Middleware from './middleware';
 import Theme from './theme';
 
@@ -43,6 +44,15 @@ export default class Themer {
   }
 
   /**
+   * Return all registered variants
+   *
+   * @return {Object} Collections of middleware functions
+   */
+  getVariants() {
+    return this.theme.getVariants();
+  }
+
+  /**
    * Return the current themes unique ID
    *
    * @return {uuid}
@@ -56,7 +66,7 @@ export default class Themer {
    * The flattened object will give priority to local variable definitions if they conflict
    * with global vars.
    *
-   * @param  {Object} variables Variables defined by the gloval application theme
+   * @param  {Object} variables Variables defined by the global application theme
    * @return {Object}           Resolved theme variables, where local vars take priority
    */
   getThemeVariables(variables = {}) {
@@ -86,7 +96,7 @@ export default class Themer {
 
   /**
    * Executes all of the methods in the middleware registry. Middleware methods
-   * expect the snippet and them.styles to be passed in as properties
+   * expect the snippet and theme.styles to be passed in as properties
    *
    * @param  {Function} snippet Function that returns valid HTML markup
    * @return {Function}         Resolved results of all middleware methods
@@ -107,7 +117,6 @@ export default class Themer {
     const variables = theme.getVariables();
     const styles = theme.getStyles(variables);
     const resolvedSnippet = this.middleware.resolve(snippet, styles);
-
     return {
       snippet: resolvedSnippet,
       theme: {
@@ -125,9 +134,10 @@ export default class Themer {
    * @return {Object}           The rendered HTML with appended styles
    */
   render(snippet, props = {}) {
-    return this.resolveMiddleware(snippet)(Object.assign(props, {
-      styles: this.theme.getStyles(),
+    const styles = variantApply(props, this.theme);
+    const resolvedSnippet = this.resolveMiddleware(snippet)(Object.assign(props, {
+      styles,
     }));
+    return resolvedSnippet;
   }
-
 }

--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -39,7 +39,7 @@ export default class Middleware {
 
   /**
    * Executes all of the methods in the middleware registry. Middleware methods
-   * expect the snippet and them.styles to be passed in as properties
+   * expect the snippet and theme.styles to be passed in as properties
    *
    * @param  {Function} snippet Function that returns valid HTML markup
    * @param  {Object}   styles  Executes all middleware function on snippet

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -121,6 +121,7 @@ export default class Theme {
       .reduce((previousTheme, currentTheme) => ({
         styles: Theme.combineByAttributes('styles', previousTheme, currentTheme),
         variables: Theme.combineByAttributes('variables', previousTheme, currentTheme),
+        variants: Theme.combineByAttributes('variants', previousTheme, currentTheme),
       }), {});
 
     resolvedTheme.id = uuid();
@@ -165,6 +166,15 @@ export default class Theme {
     }
 
     return this.theme.styles;
+  }
+
+  /**
+   * Returns a flattened variant object based on the raw theme and vars that were passed in
+   *
+   * @return {Object}           Resolved variants object
+   */
+  getVariants() {
+    return this.theme.variants;
   }
 
 }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -4,7 +4,7 @@
  * of the MIT license. See the LICENSE file for details.
  */
 
-import { isFunction, isArray, find } from 'lodash';
+import { each, find, isArray, isFunction } from 'lodash';
 import Themer from './../Themer';
 
 /**
@@ -52,4 +52,24 @@ export function resolve(arrayToResolve, ...args) {
 
     return val;
   }, {});
+}
+
+/**
+ * Append variants passed as "true" props to the root style element
+ *
+ * @param {Object} props             The props passed to the render method
+ * @param {Object} theme             The theme as calculated
+ * @return {Object}                  The styles as per post-variant processing
+ * @public
+ */
+export function variantApply(props, theme) {
+  const styles = theme.getStyles();
+  each(props, (propValue, propKey) => {
+    each(theme.getVariants(), (variantValue, variantKey) => {
+      if (propKey === variantKey && propValue === true) {
+        styles.root += ` ${styles[variantKey]}`;
+      }
+    });
+  });
+  return styles;
 }

--- a/tests/Themer.spec.js
+++ b/tests/Themer.spec.js
@@ -18,15 +18,21 @@ let testInstance = null;
 
 const testTheme = {
   styles: {
-    header: 'big-text-class',
+    root: 'big-text-class',
+    stop: 'red-black-class',
+    go: 'green-grass-class',
   },
   variables: () => ({
     color: 'red',
   }),
+  variants: {
+    stop: false,
+    go: false,
+  },
 };
 
 const snippet = (props) =>
-  `<h1 class="${props.styles.header}">${props.content}</h1>`;
+  `<h1 class="${props.styles.root}">${props.content}</h1>`;
 
 describe('Themer', () => {
   describe('exports', () => {
@@ -87,12 +93,13 @@ describe('Themer', () => {
       expect(testInstance.setTheme).to.be.a('function');
     });
 
-    it('should provide a getter methods for theme id, variables and styles', () => {
+    it('should provide a getter methods for theme id, variables, variants, and styles', () => {
       testInstance = create({ themes: [testTheme] });
 
       expect(testInstance.getThemeId).to.be.a('function');
       expect(testInstance.getThemeStyles).to.be.a('function');
       expect(testInstance.getThemeVariables).to.be.a('function');
+      expect(testInstance.getVariants).to.be.a('function');
     });
 
     it('accepts a non keyed array of theme attributes and adds styles key', () => {
@@ -102,6 +109,7 @@ describe('Themer', () => {
       expect(testInstance.getThemeId).to.be.a('function');
       expect(testInstance.getThemeStyles).to.be.a('function');
       expect(testInstance.getThemeVariables()).to.deep.equal({});
+      expect(testInstance.getVariants()).to.deep.equal({});
     });
 
     it('will use theme1.styles if theme2.styles does not exist', () => {
@@ -114,6 +122,13 @@ describe('Themer', () => {
     it('should throw an error if theme is not an object or function', () => {
       testInstance = create();
       expect(() => testInstance.setTheme([1])).to.throw();
+    });
+
+    it('should return an object of variants if supplied', () => {
+      testInstance = create({ themes: [testTheme] });
+      const variantObj = testInstance.getVariants();
+      const expectedResult = { stop: false, go: false };
+      expect(variantObj).to.deep.equal(expectedResult);
     });
 
     it('should generated a new theme object when using .setTheme() on an existing Themer', () => {
@@ -132,7 +147,7 @@ describe('Themer', () => {
 
       testInstance = create({ themes: [testFunctionTheme] });
       const renderedSnippet = testInstance.render(snippet, { content: 'Hello' });
-      expect(renderedSnippet).to.equal(`<h1 class="${testFunctionTheme.styles().header}">Hello</h1>`);
+      expect(renderedSnippet).to.equal(`<h1 class="${testFunctionTheme.styles().root}">Hello</h1>`);
     });
 
     it('should return the resolved snippet and theme attributes', () => {
@@ -162,6 +177,13 @@ describe('Themer', () => {
       const renderedSnippet = testInstance.render(snippet, { content: 'Hello' });
 
       expect(renderedSnippet).to.equal('<h1 class="big-text-class">Hello</h1>');
+    });
+
+    it('should provide the rendered HTML snippet with styles resolved and mapped with variant support', () => {
+      testInstance = create({ themes: [testTheme] });
+      const renderedSnippet = testInstance.render(snippet, { content: 'Hello', stop: true, go: true });
+
+      expect(renderedSnippet).to.equal('<h1 class="big-text-class red-black-class green-grass-class">Hello</h1>');
     });
 
     it('should run the middleware functions before render', () => {


### PR DESCRIPTION
## Status
**READY**

## Description
Variants is a framework agonistic methodology to add classes to an existing theme for a component (root theme node). This is accomplished by toggling of boolean values of the variant via props with the classnames being in the theme object.

In order to accomplish this switching I added 3 methods - theme.getVariants, variantApply, and themer.getVariants.

theme.getVariants - pulls the variants from the the passed in theme.
themer.getVariants - references theme.getVariants to make variants accessible to outside packages - like react-themer
variantApply - loops through all variants and checks if the prop with the same key is true then add the classname to the root node of the theme. 