### PR TITLE
Add `props.classes` to themed snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,17 +31,13 @@ npm install ca-ui-themer --save
 import themer from 'ca-ui-themer';
 import theme from './styles.css'; // CSS Modules
 
-const headerHtmlSnippet = (props) => {
-  const { styles } = props.theme;
+const headerHtmlSnippet = ({ classes, content }) => `
+  <div class="${classes.root}">
+    <h1 class="${classes.title}">${content}</p>
+  </div>
+`;
 
-  return `
-    <div class="${styles.root}">
-      <h1 class="${styles.title}">'${props.content}'</p>
-    </div>
-  `;
-};
-
-export default themer(headerHtmlSnippet, theme);
+export default themer(theme)(headerHtmlSnippet);
 ```
 
 ## Development

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -111,6 +111,18 @@ export function combineByAttributes(attr, obj1 = {}, obj2 = {}) {
 
 
 /**
+ * Map resolved theme to snippet props
+ *
+ * @param {Object} props         The props passed to the snippet
+ * @param {Object} resolvedTheme The resolved theme object
+ * @return {Object}              The mapped themed props
+ * @public
+ */
+export function mapThemeProps(props, resolvedTheme) {
+  return { ...props, theme: resolvedTheme, classes: resolvedTheme.styles };
+}
+
+/**
  * Check if variant value matches corresponding prop value
  *
  * @param {any} variantPropVal The variant value
@@ -175,9 +187,5 @@ export function applyVariantsProps(props) {
     styles: mappedStyles,
   });
 
-  return { ...mappedProps, theme: mappedTheme };
-}
-
-export function mapThemeProps(props, resolvedTheme) {
-  return { ...props, theme: resolvedTheme, classes: resolvedTheme.styles };
+  return mapThemeProps(mappedProps, mappedTheme);
 }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -179,5 +179,5 @@ export function applyVariantsProps(props) {
 }
 
 export function mapThemeProps(props, resolvedTheme) {
-  return { ...props, theme: resolvedTheme };
+  return { ...props, theme: resolvedTheme, classes: resolvedTheme.styles };
 }

--- a/tests/fixtures/index.js
+++ b/tests/fixtures/index.js
@@ -37,7 +37,7 @@ export const testThemeFunction = {
   }),
 };
 
-export const snippet = (props) =>
-  `<h1 class="${props.theme.styles.root}">` +
-    `${props.content}` +
+export const snippet = ({ classes, content }) =>
+  `<h1 class="${classes.root}">` +
+    `${content}` +
   '</h1>';

--- a/tests/utils/index.spec.js
+++ b/tests/utils/index.spec.js
@@ -127,6 +127,7 @@ describe('utils', () => {
       const mappedProps = {
         content: 'Hello',
         theme: { styles: { root: 'root-class-123 test-123', test: 'test-123' }, variants: { test: true } },
+        classes: { root: 'root-class-123 test-123', test: 'test-123' },
       };
       expect(applyVariantsProps(testProps)).toEqual(mappedProps);
     });
@@ -137,6 +138,7 @@ describe('utils', () => {
         content: 'Hello',
         test: true,
         theme: { styles: { root: 'root-class-123' }, variants: {} },
+        classes: { root: 'root-class-123' },
       };
       expect(applyVariantsProps(testProps)).toEqual(mappedProps);
     });
@@ -151,6 +153,7 @@ describe('utils', () => {
       const mappedProps = {
         content: 'Hello',
         theme: { styles: { root: 'root-class-123 test-123', test: 'test-123' }, variants: { test: true } },
+        classes: { root: 'root-class-123 test-123', test: 'test-123' },
       };
       expect(applyVariantsProps(testProps)).toEqual(mappedProps);
     });
@@ -165,6 +168,7 @@ describe('utils', () => {
       const mappedProps = {
         content: 'Hello',
         theme: { styles: { root: 'root-class-123', test: 'test-123' }, variants: {} },
+        classes: { root: 'root-class-123', test: 'test-123' },
       };
       expect(applyVariantsProps(testProps)).toEqual(mappedProps);
     });
@@ -180,6 +184,7 @@ describe('utils', () => {
           styles: { root: 'root-class-123 test-1 test-2', test1: 'test-1', test2: 'test-2' },
           variants: { test1: true, test2: true },
         },
+        classes: { root: 'root-class-123 test-1 test-2', test1: 'test-1', test2: 'test-2' },
       };
       expect(applyVariantsProps(testProps)).toEqual(mappedProps);
     });

--- a/tests/utils/index.spec.js
+++ b/tests/utils/index.spec.js
@@ -194,7 +194,11 @@ describe('utils', () => {
       const testResolvedTheme = { styles: { root: 'root-class-123' } };
       const testProps = { content: 'Hello' };
       const mappedProps = mapThemeProps(testProps, testResolvedTheme);
-      expect(mappedProps).toEqual({ ...testProps, theme: testResolvedTheme });
+      expect(mappedProps).toEqual({
+        ...testProps,
+        theme: testResolvedTheme,
+        classes: testResolvedTheme.styles,
+      });
     });
   });
 });


### PR DESCRIPTION
## Status
**READY**

## Description
Add `classes` to themed snippet props to allow for quick access to resolved theme styles.

## Impacted Areas in Application

* `utils.mapThemeProps`
